### PR TITLE
Eschew platform-dependent `usize` in favor of `u64`.

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -13,13 +13,13 @@ pub const SUBSIDY_SLOW_START_INTERVAL: Height = 20_000;
 pub const BLOSSOM_ACTIVATION: Height = 653_600;
 
 /// Transcription from `zcash/src/consensus/params.h`
-pub const PRE_BLOSSOM_POW_TARGET_SPACING: usize = 150;
+pub const PRE_BLOSSOM_POW_TARGET_SPACING: u64 = 150;
 
 /// Transcription from `zcash/src/consensus/params.h`
-pub const POST_BLOSSOM_POW_TARGET_SPACING: usize = 75;
+pub const POST_BLOSSOM_POW_TARGET_SPACING: u64 = 75;
 
 /// Transcription from `zcash/src/consensus/params.h`
-pub const BLOSSOM_POW_TARGET_SPACING_RATIO: usize =
+pub const BLOSSOM_POW_TARGET_SPACING_RATIO: u64 =
     PRE_BLOSSOM_POW_TARGET_SPACING / POST_BLOSSOM_POW_TARGET_SPACING;
 
 /// Transcription from `zcash/src/consensus/params.h`

--- a/src/halving.rs
+++ b/src/halving.rs
@@ -3,7 +3,7 @@ use crate::units::Height;
 
 const FIRST_HALVING: Height = 1_046_400;
 
-pub fn halving_height(halvingnum: usize) -> Height {
+pub fn halving_height(halvingnum: u64) -> Height {
     if halvingnum == 0 {
         0
     } else {

--- a/src/subsidy/nu5.rs
+++ b/src/subsidy/nu5.rs
@@ -44,7 +44,7 @@ pub fn block_subsidy(height: Height) -> Zat {
 }
 
 // Transcription of `zcash/src/consensus/params.cpp` `Params::Halving`
-fn halvings_at(height: Height) -> usize {
+fn halvings_at(height: Height) -> u64 {
     // BUG This case not handled in zcashd!
     if height < SUBSIDY_SLOW_START_SHIFT {
         0

--- a/src/subsidy/nu5/tests.rs
+++ b/src/subsidy/nu5/tests.rs
@@ -114,6 +114,6 @@ const POST_BLOSSOM_HALVING_INTERVAL_PLUS_1: Height = POST_BLOSSOM_HALVING_INTERV
 #[test_case(
     SIXTY_FIFTH_HALVING => (65, 0)
 )]
-fn halvings_and_subsidy(height: Height) -> (usize, Zat) {
+fn halvings_and_subsidy(height: Height) -> (u64, Zat) {
     (super::halvings_at(height), super::block_subsidy(height))
 }

--- a/src/timebuckets/tests.rs
+++ b/src/timebuckets/tests.rs
@@ -11,7 +11,7 @@ use test_case::test_case;
 #[test_case(4)]
 #[test_case(42)]
 #[test_case(123)]
-fn test_across_boundary(halvingnum: usize) {
+fn test_across_boundary(halvingnum: u64) {
     let zec_blocks_per_btc_blocks = 8;
     let hh1 = halving_height(halvingnum);
     let start = hh1 - 2 * zec_blocks_per_btc_blocks;

--- a/src/units.rs
+++ b/src/units.rs
@@ -1,5 +1,5 @@
 /// A height or number of blocks
-pub type Height = usize;
+pub type Height = u64;
 
 /// A number of zatoshi
-pub type Zat = usize;
+pub type Zat = u64;


### PR DESCRIPTION
`u64` should be spec-sufficient for zatoshi and heights. HT @teor2345